### PR TITLE
Custom human format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *coverage/
 *node_modules/
 
+# Temporary files
+*.swp
+
 # Build artefacts
 *build/
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ If you want to enable all log levels at once, you can provide a `*` character as
 $ export LOG_LEVELS=*
 ```
 
+### Restricting `debug` logging per module
+
+If `debug` logging is enabled (`export LOG_LEVELS=*`), this can be restricted
+to specific modules, by setting the `LOG_DEBUG_MODULES` environment variable.
+This must hold a comma-separated list of the modules to enable.
+
+```bash
+$ export LOG_DEBUG_MODULES=module1,@scoped/module2
+```
+
 ### Setting custom log levels
 
 If you want to change the default log levels, i.e. define other log levels, change colors or define which log levels are enabled by default, call the `use` function of flaschenpost.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ logger.info('App started.');
 
 #### Handling meta data
 
-If you want to provide additional meta data, use an object as second parameter.
+If you want to provide additional meta data, add a second parameter. This can
+be any type that can be stringified.
 
 ```javascript
 logger.info('App started.', {
@@ -51,6 +52,14 @@ logger.info('App started.', {
     baz: 23
   }
 });
+
+logger.info('A string.', 'foo');
+
+logger.info('A number.', 23);
+
+logger.info('An array.', [42, 23]);
+
+logger.info('An error.', new Error('error'));
 ```
 
 #### Defining the log target

--- a/README.md
+++ b/README.md
@@ -65,6 +65,34 @@ json  | The default json format.
 
 *Please note that by providing `human` you can force flaschenpost to always show human-readable output, no matter whether there is a TTY or not.*
 
+#### Customizing the human-readable format.
+
+Use the environment variable `FLASCHENPOST_HUMAN_FORMAT` to customize the human-readable format and to adjust to your needs.
+
+Option              | Description
+--------------------|--------------------------------------------
+%application        | Name of the main application
+%applicationVersion | Version of the main application
+%date               | Date in YYYY-MM-DD UTC
+%host               | Hostname
+%id                 | Log message ID
+%level              | Log level (debug, info, warn, error, fatal)
+%coloredLevel       | Log level colored
+%message            | Log message
+%coloredMessage     | Log message colored by log level
+%metadata           | Metadata, stringified
+%module             | Name of the module
+%moduleVersion      | Version of the module
+%ms                 | Milliseconds
+%pid                | Process ID
+%source             | Log source file
+%time               | Time in HH:mm:ss UTC
+
+Example:
+```bash
+export FLASCHENPOST_HUMAN_FORMAT='%date %time %coloredLevel %message %metadata'
+```
+
 #### Setting a custom host
 
 By default, flaschenpost uses the current host's host name in log messages. If you want to change the host name being used, call the `use` function.
@@ -94,7 +122,7 @@ If you want to change the default log levels, i.e. define other log levels, chan
 ```javascript
 flaschenpost.use('levels', {
   fatal: {
-    color: 'blue',
+    color: 'magenta',
     enabled: true
   },
   error: {

--- a/README.md
+++ b/README.md
@@ -77,20 +77,22 @@ Option              | Description
 %host               | Hostname
 %id                 | Log message ID
 %level              | Log level (debug, info, warn, error, fatal)
-%coloredLevel       | Log level colored
+%levelColored       | Log level colored
 %message            | Log message
-%coloredMessage     | Log message colored by log level
+%messageColored     | Log message colored by log level
 %metadata           | Metadata, stringified
+%metadataShort      | Metadata, stringified, no line-breaks
 %module             | Name of the module
 %moduleVersion      | Version of the module
 %ms                 | Milliseconds
+%origin             | Hostname, application & version, module & version (if different from application), source
 %pid                | Process ID
 %source             | Log source file
 %time               | Time in HH:mm:ss UTC
 
 Example:
 ```bash
-export FLASCHENPOST_HUMAN_FORMAT='%date %time %coloredLevel %message %metadata'
+export FLASCHENPOST_HUMAN_FORMAT='%date %time %levelColored %message %metadata'
 ```
 
 #### Setting a custom host
@@ -106,7 +108,7 @@ flaschenpost.use('host', 'example.com');
 By default, only the log levels `fatal`, `error`, `warn` and `info` are printed to the console. If you want to change this, set the environment variable `LOG_LEVELS` to the comma-separated list of desired log levels.
 
 ```bash
-$ export LOG_LEVELS=debug,info
+$ export LOG_LEVELS=fatal,error
 ```
 
 If you want to enable all log levels at once, you can provide a `*` character as value for the `LOG_LEVELS` environment variable.

--- a/README.md
+++ b/README.md
@@ -42,24 +42,11 @@ logger.info('App started.');
 
 #### Handling meta data
 
-If you want to provide additional meta data, add a second parameter. This can
-be any type that can be stringified.
+If you want to provide additional meta data, add a second parameter.
 
 ```javascript
-logger.info('App started.', {
-  name: 'foo',
-  bar: {
-    baz: 23
-  }
-});
-
-logger.info('A string.', 'foo');
-
-logger.info('A number.', 23);
-
-logger.info('An array.', [42, 23]);
-
-logger.info('An error.', new Error('error'));
+logger.info('App started.', { port: 3000 });
+logger.info('App started.', 3000);
 ```
 
 #### Defining the log target

--- a/examples/customHumanReadable.js
+++ b/examples/customHumanReadable.js
@@ -13,35 +13,44 @@ logger.info(process.env.FLASCHENPOST_HUMAN_FORMAT);
 logger.info('default', { meta: 123 });
 console.log();
 
-process.env.FLASCHENPOST_HUMAN_FORMAT = '%date %time %level %message %metadata';
+process.env.FLASCHENPOST_HUMAN_FORMAT = '%date %time %level %message %metadataShort';
 
 logger.info(process.env.FLASCHENPOST_HUMAN_FORMAT);
-logger.info('rawConsole');
-logger.info('rawConsole', { meta: 123 });
+logger.info('date/time level message');
+logger.info('date/time level message', { meta: 123 });
 console.log();
 
-process.env.FLASCHENPOST_HUMAN_FORMAT = '%date %time %coloredLevel %message %metadata';
+process.env.FLASCHENPOST_HUMAN_FORMAT = '%date %time %levelColored %message %metadata';
 
 logger.info(process.env.FLASCHENPOST_HUMAN_FORMAT);
-logger.debug('rawConsole', 1);
-logger.info('rawConsole');
-logger.warn('rawConsole');
-logger.error('rawConsole');
-logger.fatal('rawConsole');
+logger.debug('colored level', 1);
+logger.info('colored level', 2);
+logger.warn('colored level', 'warn');
+logger.error('colored level', [ 1, 2, 3 ]);
+logger.fatal('colored level', { key: 'value' });
 console.log();
 
-process.env.FLASCHENPOST_HUMAN_FORMAT = '%date %time %coloredLevel %coloredMessage %metadata';
+process.env.FLASCHENPOST_HUMAN_FORMAT = '%date %time %levelColored %messageColored %metadataShort';
 
 logger.info(process.env.FLASCHENPOST_HUMAN_FORMAT);
-logger.debug('rawConsole');
-logger.info('rawConsole');
-logger.warn('rawConsole');
-logger.error('rawConsole');
-logger.fatal('rawConsole');
+logger.debug('colored level and message', 1);
+logger.info('colored level and message', 2);
+logger.warn('colored level and message', 'warn');
+logger.error('colored level and message', [ 1, 2, 3 ]);
+logger.fatal('colored level and message', { key: 'value' });
 console.log();
 
 process.env.FLASCHENPOST_HUMAN_FORMAT = '[%date %time.%ms] (%application@%applicationVersion/%module@%moduleVersion) %level: %message (%source) %metadata';
 
 logger.info(process.env.FLASCHENPOST_HUMAN_FORMAT);
 logger.info('custom', { meta: 123 });
+console.log();
+
+process.env.FLASCHENPOST_HUMAN_FORMAT = '%messageColored (%levelColored)\n' +
+  '%origin\n' +
+  '%time.%ms@%date %pid#%id\n' +
+  '%metadata';
+
+logger.info(process.env.FLASCHENPOST_HUMAN_FORMAT);
+logger.info('nearly the default human format', { meta: 123 });
 console.log();

--- a/examples/customHumanReadable.js
+++ b/examples/customHumanReadable.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+'use strict';
+
+const flaschenpost = require('../lib/flaschenpost');
+const logger = flaschenpost.getLogger();
+
+/* eslint-disable no-process-env */
+/* eslint-disable no-console */
+
+Reflect.deleteProperty(process.env, 'FLASCHENPOST_HUMAN_FORMAT');
+
+logger.info(process.env.FLASCHENPOST_HUMAN_FORMAT);
+logger.info('default', { meta: 123 });
+console.log();
+
+process.env.FLASCHENPOST_HUMAN_FORMAT = '%date %time %level %message %metadata';
+
+logger.info(process.env.FLASCHENPOST_HUMAN_FORMAT);
+logger.info('rawConsole');
+logger.info('rawConsole', { meta: 123 });
+console.log();
+
+process.env.FLASCHENPOST_HUMAN_FORMAT = '%date %time %coloredLevel %message %metadata';
+
+logger.info(process.env.FLASCHENPOST_HUMAN_FORMAT);
+logger.debug('rawConsole', 1);
+logger.info('rawConsole');
+logger.warn('rawConsole');
+logger.error('rawConsole');
+logger.fatal('rawConsole');
+console.log();
+
+process.env.FLASCHENPOST_HUMAN_FORMAT = '%date %time %coloredLevel %coloredMessage %metadata';
+
+logger.info(process.env.FLASCHENPOST_HUMAN_FORMAT);
+logger.debug('rawConsole');
+logger.info('rawConsole');
+logger.warn('rawConsole');
+logger.error('rawConsole');
+logger.fatal('rawConsole');
+console.log();
+
+process.env.FLASCHENPOST_HUMAN_FORMAT = '[%date %time.%ms] (%application@%applicationVersion/%module@%moduleVersion) %level: %message (%source) %metadata';
+
+logger.info(process.env.FLASCHENPOST_HUMAN_FORMAT);
+logger.info('custom', { meta: 123 });
+console.log();

--- a/examples/logError.js
+++ b/examples/logError.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+'use strict';
+
+const flaschenpost = require('../lib/flaschenpost');
+const logger = flaschenpost.getLogger();
+
+/* eslint-disable no-process-env */
+/* eslint-disable no-console */
+
+Reflect.deleteProperty(process.env, 'FLASCHENPOST_HUMAN_FORMAT');
+
+logger.info(process.env.FLASCHENPOST_HUMAN_FORMAT);
+logger.info(new Error('Something failed'));
+console.log();
+
+process.env.FLASCHENPOST_HUMAN_FORMAT = '%date %time %level %message';
+
+logger.info(process.env.FLASCHENPOST_HUMAN_FORMAT);
+logger.info(new Error('Something failed'));
+console.log();

--- a/lib/Configuration/index.js
+++ b/lib/Configuration/index.js
@@ -6,9 +6,11 @@ const _ = require('lodash'),
       varname = require('varname');
 
 const defaultLevels = require('../defaultLevels.json'),
-      parseEnvironmentVariable = require('./parseEnvironmentVariable');
+      parseLogDebugModulesEnvironmentVariable = require('./parseLogDebugModulesEnvironmentVariable'),
+      parseLogLevelsEnvironmentVariable = require('./parseLogLevelsEnvironmentVariable');
 
 const Configuration = function () {
+  this.debugModules = parseLogDebugModulesEnvironmentVariable();
   this.setLevels(_.cloneDeep(defaultLevels));
   this.setHost(os.hostname());
 };
@@ -30,7 +32,7 @@ Configuration.prototype.setLevels = function (levels) {
 
   this.levels = levels;
 
-  let enabledLogLevels = parseEnvironmentVariable();
+  let enabledLogLevels = parseLogLevelsEnvironmentVariable();
 
   if (enabledLogLevels.length === 0) {
     return;

--- a/lib/Configuration/parseLogDebugModulesEnvironmentVariable.js
+++ b/lib/Configuration/parseLogDebugModulesEnvironmentVariable.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const parseLogDebugModulesEnvironmentVariable = function () {
+  /* eslint-disable no-process-env, newline-after-var */
+  const logDebugModules = process.env.LOG_DEBUG_MODULES;
+  /* eslint-enable no-process-env, newline-after-var */
+
+  if (!logDebugModules) {
+    return undefined;
+  }
+
+  return logDebugModules.split(',');
+};
+
+module.exports = parseLogDebugModulesEnvironmentVariable;

--- a/lib/Configuration/parseLogLevelsEnvironmentVariable.js
+++ b/lib/Configuration/parseLogLevelsEnvironmentVariable.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const parseEnvironmentVariable = function () {
+const parseLogLevelsEnvironmentVariable = function () {
   /* eslint-disable no-process-env, newline-after-var */
   const logLevels = process.env.LOG_LEVELS;
   /* eslint-enable no-process-env, newline-after-var */
@@ -12,4 +12,4 @@ const parseEnvironmentVariable = function () {
   return logLevels.split(',').map(logLevel => logLevel.trim().toLowerCase());
 };
 
-module.exports = parseEnvironmentVariable;
+module.exports = parseLogLevelsEnvironmentVariable;

--- a/lib/defaultLevels.json
+++ b/lib/defaultLevels.json
@@ -1,6 +1,6 @@
 {
   "fatal": {
-    "color": "blue",
+    "color": "magenta",
     "enabled": true
   },
 

--- a/lib/flaschenpost.js
+++ b/lib/flaschenpost.js
@@ -70,7 +70,7 @@ flaschenpost.getLogger = function (source) {
     logger[levelName] = (message, metadata) => {
       if (levelName === 'debug' &&
           this.configuration.debugModules &&
-          !_.includes(this.configuration.debugModules, logger.module)
+          !_.includes(this.configuration.debugModules, logger.module.name)
       ) {
         // Don't log this message, as LOG_DEBUG_MODULES are set,
         // but do not include the current module.

--- a/lib/flaschenpost.js
+++ b/lib/flaschenpost.js
@@ -68,6 +68,15 @@ flaschenpost.getLogger = function (source) {
     }
 
     logger[levelName] = (message, metadata) => {
+      if (levelName === 'debug' &&
+          this.configuration.debugModules &&
+          !_.includes(this.configuration.debugModules, logger.module)
+      ) {
+        // Don't log this message, as LOG_DEBUG_MODULES are set,
+        // but do not include the current module.
+        return;
+      }
+
       if (typeof message !== 'string') {
         try {
           message = JSON.stringify(message);

--- a/lib/flaschenpost.js
+++ b/lib/flaschenpost.js
@@ -4,7 +4,8 @@ const _ = require('lodash'),
       appRootPath = require('app-root-path'),
       findRoot = require('find-root'),
       processenv = require('processenv'),
-      stackTrace = require('stack-trace');
+      stackTrace = require('stack-trace'),
+      stringifyObject = require('stringify-object');
 
 const Configuration = require('./Configuration'),
       FormatterGelf = require('./formatters/Gelf'),
@@ -79,7 +80,23 @@ flaschenpost.getLogger = function (source) {
 
       if (typeof message !== 'string') {
         try {
-          message = JSON.stringify(message);
+          if (message instanceof Error) {
+            const plainObject = {};
+
+            Reflect.ownKeys(message).forEach(errorObjectKey => {
+              plainObject[errorObjectKey] = message[errorObjectKey];
+            });
+
+            message = `ERROR: ${stringifyObject(plainObject, {
+              indent: '  ',
+              singleQuotes: true
+            }).replace(/\\n/g, '\n')}`;
+          } else {
+            message = stringifyObject(message, {
+              indent: '  ',
+              singleQuotes: true
+            }).replace(/\\n/g, '\n');
+          }
         } catch (err) {
           throw new Error('Failed to stringify message.');
         }

--- a/lib/flaschenpost.js
+++ b/lib/flaschenpost.js
@@ -68,14 +68,11 @@ flaschenpost.getLogger = function (source) {
     }
 
     logger[levelName] = (message, metadata) => {
-      if (!message) {
-        message = '';
-      }
       if (typeof message !== 'string') {
         try {
           message = JSON.stringify(message);
         } catch (err) {
-          throw new Error('Message can not be stringified.');
+          throw new Error('Failed to stringify message.');
         }
       }
 

--- a/lib/flaschenpost.js
+++ b/lib/flaschenpost.js
@@ -69,10 +69,14 @@ flaschenpost.getLogger = function (source) {
 
     logger[levelName] = (message, metadata) => {
       if (!message) {
-        throw new Error('Message is missing.');
+        message = '';
       }
       if (typeof message !== 'string') {
-        throw new Error('Message must be a string.');
+        try {
+          message = JSON.stringify(message);
+        } catch (err) {
+          throw new Error('Message can not be stringified.');
+        }
       }
 
       letter.write({

--- a/lib/formatters/HumanReadable.js
+++ b/lib/formatters/HumanReadable.js
@@ -39,22 +39,105 @@ HumanReadable.prototype._transform = function (chunk, encoding, callback) {
     origin += ` (${chunk.source})`;
   }
 
-  result += colorize(`${chunk.message} (${chunk.level})`, chunk.level, 'bold');
-  result += '\n';
-  result += colorize(origin, 'white');
-  result += '\n';
-  /* eslint-disable max-len */
-  result += colorize(`${timestamp.format('HH:mm:ss.SSS')}@${timestamp.format('YYYY-MM-DD')} ${chunk.pid}#${chunk.id}`, 'gray');
-  /* eslint-enable max-len */
-  result += '\n';
-  if (chunk.metadata) {
-    result += colorize(stringifyObject(chunk.metadata, {
-      indent: '  ',
-      singleQuotes: true
-    }).replace(/\\n/g, '\n'), 'gray');
+  /* eslint-disable no-process-env */
+  if (process.env.FLASCHENPOST_HUMAN_FORMAT) {
+//    console.log(process.env.FLASCHENPOST_HUMAN_FORMAT.split(/(%\w+(?::\w+)?)/g));
+    process.env.FLASCHENPOST_HUMAN_FORMAT.split(/(%\w+)/g).forEach(item => {
+    /* eslint-enable no-process-env */
+      switch (item) {
+        case '%application':
+          result += chunk.application.name;
+          break;
+
+        case '%applicationVersion':
+          result += chunk.application.version;
+          break;
+
+        case '%date':
+          result += timestamp.format('YYYY-MM-DD');
+          break;
+
+        case '%host':
+          result += chunk.host;
+          break;
+
+        case '%id':
+          result += chunk.id;
+          break;
+
+        case '%coloredLevel':
+          result += colorize(chunk.level, chunk.level, 'bold');
+          break;
+
+        case '%level':
+          result += chunk.level;
+          break;
+
+        case '%coloredMessage':
+          result += colorize(chunk.message, chunk.level, 'bold');
+          break;
+
+        case '%message':
+          result += chunk.message;
+          break;
+
+        case '%metadata':
+          if (chunk.metadata) {
+            result += JSON.stringify(chunk.metadata);
+          }
+          break;
+
+        case '%module':
+          result += chunk.module.name;
+          break;
+
+        case '%moduleVersion':
+          result += chunk.module.version;
+          break;
+
+        case '%ms':
+          result += timestamp.format('SSS');
+          break;
+
+        case '%pid':
+          result += chunk.pid;
+          break;
+
+        case '%source':
+          result += chunk.source;
+          break;
+
+        case '%time':
+          result += timestamp.format('HH:mm:ss');
+          break;
+
+        default:
+          if (/^%/.test(item)) {
+            throw new Error(`Unhandled custom parameter '${item}'`);
+          }
+          result += item;
+          break;
+      }
+    });
+  } else {
+    result += colorize(`${chunk.message} (${chunk.level})`, chunk.level, 'bold');
     result += '\n';
+    result += colorize(origin, 'white');
+    result += '\n';
+    /* eslint-disable max-len */
+    result += colorize(`${timestamp.format('HH:mm:ss.SSS')}@${timestamp.format('YYYY-MM-DD')} ${chunk.pid}#${chunk.id}`, 'gray');
+    /* eslint-enable max-len */
+    result += '\n';
+    if (chunk.metadata) {
+      result += colorize(stringifyObject(chunk.metadata, {
+        indent: '  ',
+        singleQuotes: true
+      }).replace(/\\n/g, '\n'), 'gray');
+      result += '\n';
+    }
+    result += colorize('\u2500'.repeat(process.stdout.columns || 80), 'gray');
   }
-  result += colorize('\u2500'.repeat(process.stdout.columns || 80), 'gray');
+
   result += '\n';
 
   this.push(result);

--- a/lib/formatters/HumanReadable.js
+++ b/lib/formatters/HumanReadable.js
@@ -41,7 +41,6 @@ HumanReadable.prototype._transform = function (chunk, encoding, callback) {
 
   /* eslint-disable no-process-env */
   if (process.env.FLASCHENPOST_HUMAN_FORMAT) {
-//    console.log(process.env.FLASCHENPOST_HUMAN_FORMAT.split(/(%\w+(?::\w+)?)/g));
     process.env.FLASCHENPOST_HUMAN_FORMAT.split(/(%\w+)/g).forEach(item => {
     /* eslint-enable no-process-env */
       switch (item) {
@@ -65,25 +64,38 @@ HumanReadable.prototype._transform = function (chunk, encoding, callback) {
           result += chunk.id;
           break;
 
-        case '%coloredLevel':
-          result += colorize(chunk.level, chunk.level, 'bold');
-          break;
-
         case '%level':
           result += chunk.level;
           break;
 
-        case '%coloredMessage':
-          result += colorize(chunk.message, chunk.level, 'bold');
+        case '%levelColored':
+          result += colorize(chunk.level, chunk.level, 'bold');
           break;
 
         case '%message':
           result += chunk.message;
           break;
 
+        case '%messageColored':
+          result += colorize(chunk.message, chunk.level, 'bold');
+          break;
+
         case '%metadata':
           if (chunk.metadata) {
-            result += JSON.stringify(chunk.metadata);
+            result += stringifyObject(chunk.metadata, {
+              indent: '  ',
+              singleQuotes: true
+            }).replace(/\\n/g, '\n');
+          }
+          break;
+
+        case '%metadataShort':
+          if (chunk.metadata) {
+            result += stringifyObject(chunk.metadata, {
+              indent: '  ',
+              inlineCharacterLimit: 200,
+              singleQuotes: true
+            }).replace(/\\n/g, '\n');
           }
           break;
 
@@ -97,6 +109,10 @@ HumanReadable.prototype._transform = function (chunk, encoding, callback) {
 
         case '%ms':
           result += timestamp.format('SSS');
+          break;
+
+        case '%origin':
+          result += origin;
           break;
 
         case '%pid':

--- a/lib/letter/Paragraph.js
+++ b/lib/letter/Paragraph.js
@@ -15,13 +15,6 @@ const Paragraph = function (id, data) {
   if (!data.level) {
     throw new Error('Level is missing.');
   }
-  if (data.metadata && typeof data.metadata !== 'object') {
-    try {
-      data.metadata = { stringified: JSON.stringify(data.metadata) };
-    } catch (err) {
-      throw new Error('Failed to stringify message.');
-    }
-  }
 
   this.host = data.host;
   this.pid = process.pid;

--- a/lib/letter/Paragraph.js
+++ b/lib/letter/Paragraph.js
@@ -15,14 +15,11 @@ const Paragraph = function (id, data) {
   if (!data.level) {
     throw new Error('Level is missing.');
   }
-  if (!data.message) {
-    data.message = '';
-  }
   if (data.metadata && typeof data.metadata !== 'object') {
     try {
       data.metadata = { stringified: JSON.stringify(data.metadata) };
     } catch (err) {
-      throw new Error('Metadata can not be stringified.');
+      throw new Error('Failed to stringify message.');
     }
   }
 

--- a/lib/letter/Paragraph.js
+++ b/lib/letter/Paragraph.js
@@ -16,10 +16,14 @@ const Paragraph = function (id, data) {
     throw new Error('Level is missing.');
   }
   if (!data.message) {
-    throw new Error('Message is missing.');
+    data.message = '';
   }
   if (data.metadata && typeof data.metadata !== 'object') {
-    throw new Error('Invalid metadata.');
+    try {
+      data.metadata = { stringified: JSON.stringify(data.metadata) };
+    } catch (err) {
+      throw new Error('Metadata can not be stringified.');
+    }
   }
 
   this.host = data.host;

--- a/test/helpers/writeDebugMessage.js
+++ b/test/helpers/writeDebugMessage.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const flaschenpost = require('../../lib/flaschenpost');
+
+const logger = flaschenpost.getLogger();
+
+logger.debug('Debug message');

--- a/test/units/Configuration/LogDebugModulesTests.js
+++ b/test/units/Configuration/LogDebugModulesTests.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const path = require('path');
+
+const assert = require('assertthat'),
+      nodeenv = require('nodeenv'),
+      shell = require('shelljs');
+
+suite('LOG_LEVELS and LOG_DEBUG_MODULES', () => {
+  test('debug disabled', done => {
+    nodeenv({
+      LOG_LEVELS: undefined,
+      LOG_DEBUG_MODULES: undefined
+    }, restore => {
+      shell.exec('node writeDebugMessage.js', {
+        cwd: path.join(__dirname, '..', '..', 'helpers')
+      }, (code, stdout, stderr) => {
+        assert.that(code).is.equalTo(0);
+        assert.that(stdout).is.equalTo('');
+        assert.that(stderr).is.equalTo('');
+        restore();
+        done();
+      });
+    });
+  });
+
+  test('all log levels enabled', done => {
+    nodeenv({
+      LOG_LEVELS: '*',
+      LOG_DEBUG_MODULES: undefined
+    }, restore => {
+      shell.exec('node writeDebugMessage.js', {
+        cwd: path.join(__dirname, '..', '..', 'helpers')
+      }, (code, stdout, stderr) => {
+        assert.that(code).is.equalTo(0);
+        assert.that(stdout).is.not.equalTo('');
+        assert.that(stderr).is.equalTo('');
+        restore();
+        done();
+      });
+    });
+  });
+
+  test('debug enabled', done => {
+    nodeenv({
+      LOG_LEVELS: 'debug',
+      LOG_DEBUG_MODULES: undefined
+    }, restore => {
+      shell.exec('node writeDebugMessage.js', {
+        cwd: path.join(__dirname, '..', '..', 'helpers')
+      }, (code, stdout, stderr) => {
+        assert.that(code).is.equalTo(0);
+        assert.that(stdout).is.not.equalTo('');
+        assert.that(stderr).is.equalTo('');
+        restore();
+        done();
+      });
+    });
+  });
+
+  test('restricted by module', done => {
+    nodeenv({
+      LOG_LEVELS: 'debug',
+      LOG_DEBUG_MODULES: 'other'
+    }, restore => {
+      shell.exec('node writeDebugMessage.js', {
+        cwd: path.join(__dirname, '..', '..', 'helpers')
+      }, (code, stdout, stderr) => {
+        assert.that(code).is.equalTo(0);
+        assert.that(stdout).is.equalTo('');
+        assert.that(stderr).is.equalTo('');
+        restore();
+        done();
+      });
+    });
+  });
+});

--- a/test/units/Configuration/parseLogDebugModulesEnvironmentVariableTests.js
+++ b/test/units/Configuration/parseLogDebugModulesEnvironmentVariableTests.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const assert = require('assertthat'),
+      nodeenv = require('nodeenv');
+
+const parseLogDebugModulesEnvironmentVariable = require('../../../lib/Configuration/parseLogDebugModulesEnvironmentVariable');
+
+suite('parseLogDebugModulesEnvironmentVariable', () => {
+  test('is a function.', done => {
+    assert.that(parseLogDebugModulesEnvironmentVariable).is.ofType('function');
+    done();
+  });
+
+  test('returns an empty array if the environment variable is not set.', done => {
+    nodeenv('LOG_DEBUG_MODULES', undefined, restore => {
+      assert.that(parseLogDebugModulesEnvironmentVariable()).is.undefined();
+
+      restore();
+      done();
+    });
+  });
+
+  test('returns an array with a single value if the environment variable is set to a single value.', done => {
+    nodeenv('LOG_DEBUG_MODULES', 'module1', restore => {
+      assert.that(parseLogDebugModulesEnvironmentVariable()).is.equalTo([ 'module1' ]);
+
+      restore();
+      done();
+    });
+  });
+
+  test('returns an array with multiple values.', done => {
+    nodeenv('LOG_DEBUG_MODULES', 'module1,@scoped/module2', restore => {
+      assert.that(parseLogDebugModulesEnvironmentVariable()).is.equalTo([ 'module1', '@scoped/module2' ]);
+
+      restore();
+      done();
+    });
+  });
+});

--- a/test/units/Configuration/parseLogLevelsEnvironmentVariableTests.js
+++ b/test/units/Configuration/parseLogLevelsEnvironmentVariableTests.js
@@ -3,17 +3,17 @@
 const assert = require('assertthat'),
       nodeenv = require('nodeenv');
 
-const parseEnvironmentVariable = require('../../../lib/Configuration/parseEnvironmentVariable');
+const parseLogLevelsEnvironmentVariable = require('../../../lib/Configuration/parseLogLevelsEnvironmentVariable');
 
-suite('parseEnvironmentVariable', () => {
+suite('parseLogLevelsEnvironmentVariable', () => {
   test('is a function.', done => {
-    assert.that(parseEnvironmentVariable).is.ofType('function');
+    assert.that(parseLogLevelsEnvironmentVariable).is.ofType('function');
     done();
   });
 
   test('returns an empty array if the environment variable is not set.', done => {
     nodeenv('LOG_LEVELS', undefined, restore => {
-      assert.that(parseEnvironmentVariable()).is.equalTo([]);
+      assert.that(parseLogLevelsEnvironmentVariable()).is.equalTo([]);
 
       restore();
       done();
@@ -24,7 +24,7 @@ suite('parseEnvironmentVariable', () => {
   test('returns an array with a single value if the environment variable is set to a single value.', done => {
     /* eslint-enable max-len */
     nodeenv('LOG_LEVELS', 'info', restore => {
-      assert.that(parseEnvironmentVariable()).is.equalTo([ 'info' ]);
+      assert.that(parseLogLevelsEnvironmentVariable()).is.equalTo([ 'info' ]);
 
       restore();
       done();
@@ -33,7 +33,7 @@ suite('parseEnvironmentVariable', () => {
 
   test('returns an array with a single lowercased and trimmed value.', done => {
     nodeenv('LOG_LEVELS', '  Info ', restore => {
-      assert.that(parseEnvironmentVariable()).is.equalTo([ 'info' ]);
+      assert.that(parseLogLevelsEnvironmentVariable()).is.equalTo([ 'info' ]);
 
       restore();
       done();
@@ -42,7 +42,7 @@ suite('parseEnvironmentVariable', () => {
 
   test('returns an array with multiple values.', done => {
     nodeenv('LOG_LEVELS', '  Info , DEBUG  ,warN  ', restore => {
-      assert.that(parseEnvironmentVariable()).is.equalTo([ 'info', 'debug', 'warn' ]);
+      assert.that(parseLogLevelsEnvironmentVariable()).is.equalTo([ 'info', 'debug', 'warn' ]);
 
       restore();
       done();

--- a/test/units/flaschenpostTests.js
+++ b/test/units/flaschenpostTests.js
@@ -85,7 +85,7 @@ suite('flaschenpost', () => {
           assert.that(paragraph.id).is.ofType('number');
           assert.that(paragraph.timestamp).is.not.undefined();
           assert.that(paragraph.level).is.equalTo('info');
-          assert.that(paragraph.message).is.undefined();
+          assert.that(paragraph.message).is.equalTo('undefined');
           assert.that(paragraph.application.name).is.equalTo('flaschenpost');
           assert.that(paragraph.application.version).is.not.undefined();
           assert.that(paragraph.module).is.equalTo({
@@ -123,6 +123,34 @@ suite('flaschenpost', () => {
         });
 
         logger.info(42);
+      });
+
+      test('writes an error to a letter.', done => {
+        flaschenpost.use('host', 'example.com');
+
+        const logger = flaschenpost.getLogger(__filename);
+
+        letter.once('data', paragraph => {
+          assert.that(paragraph).is.ofType('object');
+          assert.that(paragraph.pid).is.equalTo(process.pid);
+          assert.that(paragraph.id).is.ofType('number');
+          assert.that(paragraph.timestamp).is.not.undefined();
+          assert.that(paragraph.level).is.equalTo('info');
+          assert.that(paragraph.message).is.startingWith('ERROR: {\n');
+          assert.that(paragraph.message).is.containing(`stack: 'Error: Something failed\n`);
+          assert.that(paragraph.message).is.endingWith(`message: 'Something failed'\n}`);
+          assert.that(paragraph.message).is.containing('');
+          assert.that(paragraph.application.name).is.equalTo('flaschenpost');
+          assert.that(paragraph.application.version).is.not.undefined();
+          assert.that(paragraph.module).is.equalTo({
+            name: 'foo',
+            version: '0.0.1'
+          });
+          assert.that(paragraph.source).is.equalTo(__filename);
+          done();
+        });
+
+        logger.info(new Error('Something failed'));
       });
 
       test('writes the message to a letter.', done => {

--- a/test/units/flaschenpostTests.js
+++ b/test/units/flaschenpostTests.js
@@ -198,7 +198,7 @@ suite('flaschenpost', () => {
         const logger = flaschenpost.getLogger();
 
         letter.once('data', paragraph => {
-          assert.that(paragraph.metadata).is.equalTo({ stringified: '"foo"' });
+          assert.that(paragraph.metadata).is.equalTo('foo');
           done();
         });
 
@@ -209,7 +209,7 @@ suite('flaschenpost', () => {
         const logger = flaschenpost.getLogger();
 
         letter.once('data', paragraph => {
-          assert.that(paragraph.metadata).is.equalTo({ stringified: '42' });
+          assert.that(paragraph.metadata).is.equalTo(42);
           done();
         });
 

--- a/test/units/flaschenpostTests.js
+++ b/test/units/flaschenpostTests.js
@@ -85,7 +85,7 @@ suite('flaschenpost', () => {
           assert.that(paragraph.id).is.ofType('number');
           assert.that(paragraph.timestamp).is.not.undefined();
           assert.that(paragraph.level).is.equalTo('info');
-          assert.that(paragraph.message).is.equalTo('');
+          assert.that(paragraph.message).is.undefined();
           assert.that(paragraph.application.name).is.equalTo('flaschenpost');
           assert.that(paragraph.application.version).is.not.undefined();
           assert.that(paragraph.module).is.equalTo({

--- a/test/units/flaschenpostTests.js
+++ b/test/units/flaschenpostTests.js
@@ -73,22 +73,56 @@ suite('flaschenpost', () => {
     });
 
     suite('log function', () => {
-      test('throws an error when no message is given.', done => {
+      test('writes a blank message to a letter.', done => {
+        flaschenpost.use('host', 'example.com');
+
         const logger = flaschenpost.getLogger(__filename);
 
-        assert.that(() => {
-          logger.info();
-        }).is.throwing('Message is missing.');
-        done();
+        letter.once('data', paragraph => {
+          assert.that(paragraph).is.ofType('object');
+          assert.that(paragraph.host).is.equalTo('example.com');
+          assert.that(paragraph.pid).is.equalTo(process.pid);
+          assert.that(paragraph.id).is.ofType('number');
+          assert.that(paragraph.timestamp).is.not.undefined();
+          assert.that(paragraph.level).is.equalTo('info');
+          assert.that(paragraph.message).is.equalTo('');
+          assert.that(paragraph.application.name).is.equalTo('flaschenpost');
+          assert.that(paragraph.application.version).is.not.undefined();
+          assert.that(paragraph.module).is.equalTo({
+            name: 'foo',
+            version: '0.0.1'
+          });
+          assert.that(paragraph.source).is.equalTo(__filename);
+          done();
+        });
+
+        logger.info();
       });
 
-      test('throws an error when message is not a string.', done => {
+      test('writes a number message to a letter.', done => {
+        flaschenpost.use('host', 'example.com');
+
         const logger = flaschenpost.getLogger(__filename);
 
-        assert.that(() => {
-          logger.info(42);
-        }).is.throwing('Message must be a string.');
-        done();
+        letter.once('data', paragraph => {
+          assert.that(paragraph).is.ofType('object');
+          assert.that(paragraph.host).is.equalTo('example.com');
+          assert.that(paragraph.pid).is.equalTo(process.pid);
+          assert.that(paragraph.id).is.ofType('number');
+          assert.that(paragraph.timestamp).is.not.undefined();
+          assert.that(paragraph.level).is.equalTo('info');
+          assert.that(paragraph.message).is.equalTo('42');
+          assert.that(paragraph.application.name).is.equalTo('flaschenpost');
+          assert.that(paragraph.application.version).is.not.undefined();
+          assert.that(paragraph.module).is.equalTo({
+            name: 'foo',
+            version: '0.0.1'
+          });
+          assert.that(paragraph.source).is.equalTo(__filename);
+          done();
+        });
+
+        logger.info(42);
       });
 
       test('writes the message to a letter.', done => {

--- a/test/units/flaschenpostTests.js
+++ b/test/units/flaschenpostTests.js
@@ -194,6 +194,52 @@ suite('flaschenpost', () => {
         });
       });
 
+      test('handles string metadata.', done => {
+        const logger = flaschenpost.getLogger();
+
+        letter.once('data', paragraph => {
+          assert.that(paragraph.metadata).is.equalTo({ stringified: '"foo"' });
+          done();
+        });
+
+        logger.info('A string.', 'foo');
+      });
+
+      test('handles number metadata.', done => {
+        const logger = flaschenpost.getLogger();
+
+        letter.once('data', paragraph => {
+          assert.that(paragraph.metadata).is.equalTo({ stringified: '42' });
+          done();
+        });
+
+        logger.info('A string.', 42);
+      });
+
+      test('handles array metadata.', done => {
+        const logger = flaschenpost.getLogger();
+
+        letter.once('data', paragraph => {
+          assert.that(paragraph.metadata).is.equalTo([ 42, 23 ]);
+          done();
+        });
+
+        logger.info('A string.', [ 42, 23 ]);
+      });
+
+      test('handles error metadata.', done => {
+        const logger = flaschenpost.getLogger();
+
+        letter.once('data', paragraph => {
+          assert.that(paragraph.metadata.name).is.equalTo('Error');
+          assert.that(paragraph.metadata.message).is.equalTo('error');
+          assert.that(paragraph.metadata.stack).is.not.undefined();
+          done();
+        });
+
+        logger.info('A string.', new Error('error'));
+      });
+
       test('does not write a message if the log level is disabled.', done => {
         const logger = flaschenpost.getLogger(__filename);
         let counter = 0;

--- a/test/units/formatters/HumanReadableTests.js
+++ b/test/units/formatters/HumanReadableTests.js
@@ -10,7 +10,7 @@ const HumanReadable = require('../../../lib/formatters/HumanReadable');
 
 const Transform = stream.Transform;
 
-suite.only('HumanReadable', () => {
+suite('HumanReadable', () => {
   let humanReadable;
   const paragraph = {
     host: 'example.com',

--- a/test/units/formatters/HumanReadableTests.js
+++ b/test/units/formatters/HumanReadableTests.js
@@ -32,10 +32,23 @@ suite('HumanReadable', () => {
       foo: 'bar'
     }
   };
+  let suiteRestore;
 
-  suiteSetup(() => {
+  suiteSetup(done => {
     chalk.enabled = true;
     humanReadable = new HumanReadable();
+
+    nodeenv({
+      FLASCHENPOST_HUMAN_FORMAT: undefined
+    }, restore => {
+      suiteRestore = restore;
+      done();
+    });
+  });
+
+  suiteTeardown(done => {
+    suiteRestore();
+    done();
   });
 
   suite('default', () => {

--- a/test/units/formatters/HumanReadableTests.js
+++ b/test/units/formatters/HumanReadableTests.js
@@ -3,141 +3,418 @@
 const stream = require('stream');
 
 const assert = require('assertthat'),
-      chalk = require('chalk');
+      chalk = require('chalk'),
+      nodeenv = require('nodeenv');
 
 const HumanReadable = require('../../../lib/formatters/HumanReadable');
 
 const Transform = stream.Transform;
 
-suite('HumanReadable', () => {
+suite.only('HumanReadable', () => {
   let humanReadable;
+  const paragraph = {
+    host: 'example.com',
+    pid: 82517,
+    id: 0,
+    timestamp: 1415024939974,
+    level: 'info',
+    message: 'App started.',
+    application: {
+      name: 'app',
+      version: '1.2.3'
+    },
+    module: {
+      name: 'foo',
+      version: '0.0.1'
+    },
+    source: 'app.js',
+    metadata: {
+      foo: 'bar'
+    }
+  };
 
   suiteSetup(() => {
     chalk.enabled = true;
     humanReadable = new HumanReadable();
   });
 
-  test('is a transform stream.', done => {
-    assert.that(humanReadable).is.instanceOf(Transform);
-    done();
-  });
-
-  test('transforms a paragraph to a human-readable string.', done => {
-    const paragraph = {
-      host: 'example.com',
-      pid: 82517,
-      id: 0,
-      timestamp: 1415024939974,
-      level: 'info',
-      message: 'App started.',
-      application: {
-        name: 'app',
-        version: '1.2.3'
-      },
-      module: {
-        name: 'foo',
-        version: '0.0.1'
-      },
-      source: 'app.js',
-      metadata: {
-        foo: 'bar'
-      }
-    };
-
-    humanReadable.once('data', data => {
-      assert.that(chalk.stripColor(data)).is.equalTo([
-        /* eslint-disable nodeca/indent */
-        'App started. (info)',
-        'example.com::app@1.2.3::foo@0.0.1 (app.js)',
-        '14:28:59.974@2014-11-03 82517#0',
-        '{',
-        '  foo: \'bar\'',
-        '}',
-        '\u2500'.repeat(process.stdout.columns || 80),
-        ''
-        /* eslint-enable nodeca/indent */
-      ].join('\n'));
+  suite('default', () => {
+    test('is a transform stream.', done => {
+      assert.that(humanReadable).is.instanceOf(Transform);
       done();
     });
 
-    humanReadable.write(paragraph);
-  });
+    test('transforms a paragraph to a human-readable string.', done => {
+      humanReadable.once('data', data => {
+        assert.that(chalk.stripColor(data)).is.equalTo([
+          /* eslint-disable nodeca/indent */
+          'App started. (info)',
+          'example.com::app@1.2.3::foo@0.0.1 (app.js)',
+          '14:28:59.974@2014-11-03 82517#0',
+          '{',
+          '  foo: \'bar\'',
+          '}',
+          '\u2500'.repeat(process.stdout.columns || 80),
+          ''
+          /* eslint-enable nodeca/indent */
+        ].join('\n'));
+        done();
+      });
 
-  test('does not throw an error if application information is missing.', done => {
-    const paragraph = {
-      host: 'example.com',
-      pid: 82517,
-      id: 0,
-      timestamp: 1415024939974,
-      level: 'info',
-      message: 'App started.',
-      module: {
-        name: 'foo',
-        version: '0.0.1'
-      },
-      source: 'app.js',
-      metadata: {
-        foo: 'bar'
-      }
-    };
-
-    humanReadable.once('data', data => {
-      assert.that(chalk.stripColor(data)).is.equalTo([
-        /* eslint-disable nodeca/indent */
-        'App started. (info)',
-        'example.com::foo@0.0.1 (app.js)',
-        '14:28:59.974@2014-11-03 82517#0',
-        '{',
-        '  foo: \'bar\'',
-        '}',
-        '\u2500'.repeat(process.stdout.columns || 80),
-        ''
-        /* eslint-enable nodeca/indent */
-      ].join('\n'));
-      done();
+      humanReadable.write(paragraph);
     });
 
-    humanReadable.write(paragraph);
-  });
+    test('does not throw an error if application information is missing.', done => {
+      const paragraphNoApp = {
+        host: 'example.com',
+        pid: 82517,
+        id: 0,
+        timestamp: 1415024939974,
+        level: 'info',
+        message: 'App started.',
+        module: {
+          name: 'foo',
+          version: '0.0.1'
+        },
+        source: 'app.js',
+        metadata: {
+          foo: 'bar'
+        }
+      };
 
-  test('does not print information twice if application and module are the same.', done => {
-    const paragraph = {
-      host: 'example.com',
-      pid: 82517,
-      id: 0,
-      timestamp: 1415024939974,
-      level: 'info',
-      message: 'App started.',
-      application: {
-        name: 'app',
-        version: '1.2.3'
-      },
-      module: {
-        name: 'app',
-        version: '1.2.3'
-      },
-      source: 'app.js',
-      metadata: {
-        foo: 'bar'
-      }
-    };
+      humanReadable.once('data', data => {
+        assert.that(chalk.stripColor(data)).is.equalTo([
+          /* eslint-disable nodeca/indent */
+          'App started. (info)',
+          'example.com::foo@0.0.1 (app.js)',
+          '14:28:59.974@2014-11-03 82517#0',
+          '{',
+          '  foo: \'bar\'',
+          '}',
+          '\u2500'.repeat(process.stdout.columns || 80),
+          ''
+          /* eslint-enable nodeca/indent */
+        ].join('\n'));
+        done();
+      });
 
-    humanReadable.once('data', data => {
-      assert.that(chalk.stripColor(data)).is.equalTo([
-        /* eslint-disable nodeca/indent */
-        'App started. (info)',
-        'example.com::app@1.2.3 (app.js)',
-        '14:28:59.974@2014-11-03 82517#0',
-        '{',
-        '  foo: \'bar\'',
-        '}',
-        '\u2500'.repeat(process.stdout.columns || 80),
-        ''
-        /* eslint-enable nodeca/indent */
-      ].join('\n'));
-      done();
+      humanReadable.write(paragraphNoApp);
     });
 
-    humanReadable.write(paragraph);
+    test('does not print information twice if application and module are the same.', done => {
+      const paragraphSame = {
+        host: 'example.com',
+        pid: 82517,
+        id: 0,
+        timestamp: 1415024939974,
+        level: 'info',
+        message: 'App started.',
+        application: {
+          name: 'app',
+          version: '1.2.3'
+        },
+        module: {
+          name: 'app',
+          version: '1.2.3'
+        },
+        source: 'app.js',
+        metadata: {
+          foo: 'bar'
+        }
+      };
+
+      humanReadable.once('data', data => {
+        assert.that(chalk.stripColor(data)).is.equalTo([
+          /* eslint-disable nodeca/indent */
+          'App started. (info)',
+          'example.com::app@1.2.3 (app.js)',
+          '14:28:59.974@2014-11-03 82517#0',
+          '{',
+          '  foo: \'bar\'',
+          '}',
+          '\u2500'.repeat(process.stdout.columns || 80),
+          ''
+          /* eslint-enable nodeca/indent */
+        ].join('\n'));
+        done();
+      });
+
+      humanReadable.write(paragraphSame);
+    });
+  });
+
+  suite('custom', () => {
+    test('%application', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '%application'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.equalTo('app\n');
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
+
+    test('%applicationVersion', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '%applicationVersion'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.equalTo('1.2.3\n');
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
+
+    test('%date', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '%date'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.equalTo('2014-11-03\n');
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
+
+    test('%host', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '%host'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.equalTo('example.com\n');
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
+
+    test('%id', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '%id'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.equalTo('0\n');
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
+
+    test('%level', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '%level'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.equalTo('info\n');
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
+
+    test('%levelColored', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '%levelColored'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.not.equalTo('info\n');
+          assert.that(chalk.stripColor(data)).is.equalTo('info\n');
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
+
+    test('%message', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '%message'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.equalTo('App started.\n');
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
+
+    test('%messageColored', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '%messageColored'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.not.equalTo('App started.\n');
+          assert.that(chalk.stripColor(data)).is.equalTo('App started.\n');
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
+
+    test('%metadata', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '%metadata'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.equalTo([
+            '{',
+            '  foo: \'bar\'',
+            '}',
+            ''
+          ].join('\n'));
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
+
+    test('%metadataShort', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '%metadataShort'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.equalTo('{foo: \'bar\'}\n');
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
+
+    test('%module', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '%module'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.equalTo('foo\n');
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
+
+    test('%moduleVersion', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '%moduleVersion'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.equalTo('0.0.1\n');
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
+
+    test('%ms', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '%ms'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.equalTo('974\n');
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
+
+    test('%origin', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '%origin'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.equalTo('example.com::app@1.2.3::foo@0.0.1 (app.js)\n');
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
+
+    test('%pid', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '%pid'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.equalTo('82517\n');
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
+
+    test('%source', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '%source'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.equalTo('app.js\n');
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
+
+    test('%time', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '%time'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.equalTo('14:28:59\n');
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
+
+    test('combined string', done => {
+      nodeenv({
+        FLASCHENPOST_HUMAN_FORMAT: '[%date %time.%ms] (%application@%applicationVersion/%module@%moduleVersion) %level: %message (%source) %metadataShort'
+      }, restore => {
+        humanReadable.once('data', data => {
+          assert.that(data).is.equalTo('[2014-11-03 14:28:59.974] (app@1.2.3/foo@0.0.1) info: App started. (app.js) {foo: \'bar\'}\n');
+          restore();
+          done();
+        });
+
+        humanReadable.write(paragraph);
+      });
+    });
   });
 });

--- a/test/units/letter/ParagraphTests.js
+++ b/test/units/letter/ParagraphTests.js
@@ -46,21 +46,24 @@ suite('Paragraph', () => {
     done();
   });
 
-  test('throws an error if message is missing.', done => {
-    assert.that(() => {
-      /* eslint-disable no-new */
-      new Paragraph(0, { host: 'example.com', level: 'error' });
-      /* eslint-enable no-new */
-    }).is.throwing('Message is missing.');
+  test('handles message is missing.', done => {
+    const paragraph = new Paragraph(0, { host: 'example.com', level: 'error' });
+
+    assert.that(paragraph.message).is.equalTo('');
     done();
   });
 
-  test('throws an error if metadata is given and metadata is not an object.', done => {
-    assert.that(() => {
-      /* eslint-disable no-new */
-      new Paragraph(0, { host: 'example.com', level: 'error', message: 'foo', metadata: 'bar' });
-      /* eslint-enable no-new */
-    }).is.throwing('Invalid metadata.');
+  test('handles string metadata.', done => {
+    const paragraph = new Paragraph(0, { host: 'example.com', level: 'error', message: 'foo', metadata: 'bar' });
+
+    assert.that(paragraph.metadata).is.equalTo({ stringified: '"bar"' });
+    done();
+  });
+
+  test('handles number metadata.', done => {
+    const paragraph = new Paragraph(0, { host: 'example.com', level: 'error', message: 'foo', metadata: 42 });
+
+    assert.that(paragraph.metadata).is.equalTo({ stringified: '42' });
     done();
   });
 

--- a/test/units/letter/ParagraphTests.js
+++ b/test/units/letter/ParagraphTests.js
@@ -49,7 +49,7 @@ suite('Paragraph', () => {
   test('handles message is missing.', done => {
     const paragraph = new Paragraph(0, { host: 'example.com', level: 'error' });
 
-    assert.that(paragraph.message).is.equalTo('');
+    assert.that(paragraph.message).is.undefined();
     done();
   });
 

--- a/test/units/letter/ParagraphTests.js
+++ b/test/units/letter/ParagraphTests.js
@@ -56,14 +56,14 @@ suite('Paragraph', () => {
   test('handles string metadata.', done => {
     const paragraph = new Paragraph(0, { host: 'example.com', level: 'error', message: 'foo', metadata: 'bar' });
 
-    assert.that(paragraph.metadata).is.equalTo({ stringified: '"bar"' });
+    assert.that(paragraph.metadata).is.equalTo('bar');
     done();
   });
 
   test('handles number metadata.', done => {
     const paragraph = new Paragraph(0, { host: 'example.com', level: 'error', message: 'foo', metadata: 42 });
 
-    assert.that(paragraph.metadata).is.equalTo({ stringified: '42' });
+    assert.that(paragraph.metadata).is.equalTo(42);
     done();
   });
 


### PR DESCRIPTION
Hi Golo,

I have extended flaschenpost with two more configuration optione:
- FLASCHENPOST_HUMAN_FORMAT
- LOG_DEBUG_MODULES

in this context, I have also changed:
- README: "LOG_LEVELS=fatal,error" - as I doubt that it makes any sense to enable only debug & info.
- changed the default color for 'fatal' from 'blue' to 'magenta', as we had general consensus that blue does not correctly indicate a fatal error.
- changed the 'stringified' handling we had discussed in the earlier PR.

Note, this PR includes the other, outstanding PR.

Regards
  Stefan
