### PR TITLE
Add option to override source module

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ To provide a virtual file path that does not exist, pass an additional parameter
 
 ```javascript
 const logger = flaschenpost.getLogger(
-  '/vartual/path/.../app.js',
+  '/virtual/path/.../app.js',
   {
-    name: 'custome-package',
+    name: 'custom-package',
     version: '1.0.1'
   }
 );

--- a/README.md
+++ b/README.md
@@ -90,10 +90,22 @@ $ LOG_FORMATTER=human
 
 Basically, when calling the `getLoggeer` function, flaschenpost automatically detects the file from which this call is done, and infers the appropriate file name. Sometimes, this is not desired, as you may want to manually set the file name used as source.
 
-Therefor, you can provide a file path as a parameter to the `getLogger` function. Please note that this file path must be an absolute path, and that it must point to an existing file:
+Therefore, you can provide a file path as a parameter to the `getLogger` function. Please note that this file path must be an absolute path, and that it must point to an existing file:
 
 ```javascript
 const logger = flaschenpost.getLogger('/.../app.js');
+```
+
+To provide a virtual file path that does not exist, pass an additional parameter defining the module the file belongs to:
+
+```javascript
+const logger = flaschenpost.getLogger(
+  '/vartual/path/.../app.js',
+  {
+    name: 'custome-package',
+    version: '1.0.1'
+  }
+);
 ```
 
 ### Using the morgan plugin

--- a/lib/Logger.ts
+++ b/lib/Logger.ts
@@ -1,9 +1,7 @@
 import Configuration from './Configuration';
-import findRoot from 'find-root';
 import LogEntry from './LogEntry';
 import { LogLevel } from './LogLevel';
 import { PackageJson } from './PackageJson';
-import readPackageJson from './readPackageJson';
 
 class Logger {
   protected configuration: Configuration;
@@ -12,13 +10,10 @@ class Logger {
 
   protected sourcePath: string;
 
-  public constructor (configuration: Configuration, sourcePath: string) {
+  public constructor (configuration: Configuration, sourcePath: string, packageJson: PackageJson) {
     this.configuration = configuration;
     this.sourcePath = sourcePath;
-
-    const modulePath = findRoot(this.sourcePath);
-
-    this.module = readPackageJson(modulePath);
+    this.module = packageJson;
   }
 
   public fatal (message: string, metadata?: object): void {

--- a/lib/flaschenpost.ts
+++ b/lib/flaschenpost.ts
@@ -68,12 +68,10 @@ class Flaschenpost {
     return cloneDeep(this.configuration);
   }
 
-  /**
-   * Creates a logger for a given source.
-   *
-   * Checks the existence of the file at sourcePathOverride only if no
-   * packageJsonOverride is given, otherwise accepts both.
-   */
+  // Creates a logger for a given source.
+  //
+  // Checks the existence of the file at sourcePathOverride only if no
+  // packageJsonOverride is given, otherwise accepts both.
   public getLogger (sourcePathOverride?: string, packageJsonOverride?: PackageJson): Logger {
     let sourcePath = stackTrace.get()[1].getFileName();
     let packageJson;

--- a/lib/flaschenpost.ts
+++ b/lib/flaschenpost.ts
@@ -73,9 +73,6 @@ class Flaschenpost {
    *
    * Checks the existence of the file at sourcePathOverride only if no
    * packageJsonOverride is given, otherwise accepts both.
-   *
-   * @param sourcePathOverride Path to source of log messages.
-   * @param packageJsonOverride Module definition for source module.
    */
   public getLogger (sourcePathOverride?: string, packageJsonOverride?: PackageJson): Logger {
     let sourcePath = stackTrace.get()[1].getFileName();

--- a/lib/flaschenpost.ts
+++ b/lib/flaschenpost.ts
@@ -68,16 +68,18 @@ class Flaschenpost {
     return cloneDeep(this.configuration);
   }
 
-  // Creates a logger for a given source.
-  //
-  // Checks the existence of the file at sourcePathOverride only if no
-  // packageJsonOverride is given, otherwise accepts both.
-  public getLogger (sourcePathOverride?: string, packageJsonOverride?: PackageJson): Logger {
+  // When creating a logger, there are basically two options: Most probably you
+  // get a logger for an existing file, but from time to time you may want to
+  // get a logger for a virtual file. In this case you not only need to override
+  // the source path, but also the appropriate package.json definition, i.e. if
+  // you want to use a virtual file name, you must additionally provide a
+  // package.json override. If you refer to an existing file, you can skip this.
+  public getLogger (sourcePathOverride?: string, packageJsonOverrideForVirtualSourcePaths?: PackageJson): Logger {
     let sourcePath = stackTrace.get()[1].getFileName();
     let packageJson;
 
     if (sourcePathOverride) {
-      if (!packageJsonOverride) {
+      if (!packageJsonOverrideForVirtualSourcePaths) {
         /* eslint-disable no-sync */
         fs.accessSync(sourcePathOverride, fs.constants.R_OK);
         /* eslint-enable no-sync */
@@ -85,8 +87,8 @@ class Flaschenpost {
       sourcePath = sourcePathOverride;
     }
 
-    if (packageJsonOverride) {
-      packageJson = packageJsonOverride;
+    if (packageJsonOverrideForVirtualSourcePaths) {
+      packageJson = packageJsonOverrideForVirtualSourcePaths;
     } else {
       const modulePath = findRoot(sourcePath);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2907,9 +2907,9 @@
       }
     },
     "record-stdstreams": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/record-stdstreams/-/record-stdstreams-2.0.2.tgz",
-      "integrity": "sha512-Vmzzotqb+Ei1C6cmoLgfpT+yftU4NccBdvmwPvhoZr3oeerykJ8FQjYxcrkTbgUQtnk1Rtxwpn1frZGjW80Urg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/record-stdstreams/-/record-stdstreams-2.1.0.tgz",
+      "integrity": "sha512-taRFpp75MP2kQw49bQsjpzt8yOpMqxMMyCegX9pbrxkbXyQ2JcnN0HR+vMjqG3kaFLyZqXN4SoUZmIkkzw9eNg==",
       "dev": true
     },
     "reduce-flatten": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "assertthat": "4.0.2",
     "common-tags": "1.8.0",
     "nodeenv": "2.0.1",
-    "record-stdstreams": "2.0.2",
+    "record-stdstreams": "2.1.0",
     "roboter": "7.2.0",
     "strip-ansi": "5.2.0"
   },

--- a/test/integration/MorganPluginTests.ts
+++ b/test/integration/MorganPluginTests.ts
@@ -20,7 +20,7 @@ suite('MorganPlugin', (): void => {
     });
 
     test('passes writes to stream on to a flaschenpost.', async (): Promise<void> => {
-      const stop = record();
+      const stop = record(false);
       const morganPlugin = new MorganPlugin('info');
 
       morganPlugin.write('some log message');

--- a/test/integration/flaschenpostTests.ts
+++ b/test/integration/flaschenpostTests.ts
@@ -27,7 +27,7 @@ suite('flaschenpost', (): void => {
     });
 
     test('logs in a human readable format up to info level.', async (): Promise<void> => {
-      const stop = record();
+      const stop = record(false);
       const logger = flaschenpostInstance.getLogger();
 
       logger.info('Info message');
@@ -60,7 +60,7 @@ suite('flaschenpost', (): void => {
     });
 
     test('logs in json format up to debug level.', async (): Promise<void> => {
-      const stop = record();
+      const stop = record(false);
       const logger = flaschenpostInstance.getLogger();
 
       logger.info('Info message');
@@ -100,7 +100,7 @@ suite('flaschenpost', (): void => {
     });
 
     test('overwrites configuration.', async (): Promise<void> => {
-      const stop = record();
+      const stop = record(false);
 
       flaschenpostInstance.configure(new Configuration(
         [ '' ],

--- a/test/unit/flaschenpostTests.ts
+++ b/test/unit/flaschenpostTests.ts
@@ -62,4 +62,24 @@ suite('flaschenpost', (): void => {
 
     flaschenpost.configure(originalConfiguration);
   });
+
+  test('debug filtering by module using logger source override.', async (): Promise<void> => {
+    const originalConfiguration = flaschenpost.getConfiguration();
+    const stop = record();
+
+    flaschenpost.configure(
+      originalConfiguration.
+        withDebugModuleFilter([ 'not-some-module' ]).
+        withHighestEnabledLogLevel('debug')
+    );
+    const logger = flaschenpost.getLogger(undefined, { name: 'some-module', version: 'irrelevant' });
+
+    logger.debug('Some debug.');
+
+    const { stdout } = stop();
+
+    assert.that(stdout).is.equalTo('');
+
+    flaschenpost.configure(originalConfiguration);
+  });
 });

--- a/test/unit/flaschenpostTests.ts
+++ b/test/unit/flaschenpostTests.ts
@@ -40,7 +40,7 @@ suite('flaschenpost', (): void => {
 
   test('debug filtering by module.', async (): Promise<void> => {
     const originalConfiguration = flaschenpost.getConfiguration();
-    const stop = record();
+    const stop = record(false);
 
     flaschenpost.configure(
       originalConfiguration.
@@ -65,7 +65,7 @@ suite('flaschenpost', (): void => {
 
   test('debug filtering by module using logger source override.', async (): Promise<void> => {
     const originalConfiguration = flaschenpost.getConfiguration();
-    const stop = record();
+    const stop = record(false);
 
     flaschenpost.configure(
       originalConfiguration.


### PR DESCRIPTION
In the wolkenkit tests we have the problem that creating a logger for virtual files is impossible. Since I think that that is an important feature, I implemented it in `flaschenpost`.

I also refactored a bit - I think the `Logger` shouldn't do any IO in its constructor and thus moved the logic into the `getLogger` method on the base `flaschenpost` object. This also makes sense with the new feature, since the file existence check should not be done with overrides.