### PR TITLE
Export logger type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/workspace
   docker:
-    - image: node:12.10.0-alpine
+    - image: node:12.13.0-alpine
 
 only-publish-tags: &only-publish-tags
   filters:

--- a/lib/flaschenpost.ts
+++ b/lib/flaschenpost.ts
@@ -100,4 +100,4 @@ class Flaschenpost {
 }
 
 export default new Flaschenpost();
-export { Configuration, Flaschenpost, formatters, MorganPlugin };
+export { Configuration, Flaschenpost, formatters, Logger, MorganPlugin };


### PR DESCRIPTION
We use the `Logger` type in the wolkenkit but have not exported it yet here.